### PR TITLE
Convert to GorillaStack hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/_build/*
 *.pyc
+venv

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,2 +1,3 @@
 JMESPath Website, Documentation, and Specification
 Copyright 2015 James Saryerwinnie. All Rights Reserved.
+Copyright 2019 GorillaStack.

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ JMESPath Site
    :target: https://gitter.im/jmespath/chat
 
 
-This is the repo for the website: http://gorillastack-jmespath.netlify.com
+This is the repo for the website: https://gorillastack-jmespath.netlify.com
 
 Join us on our `Gitter channel <https://gitter.im/jmespath/chat>`__.
 
@@ -14,7 +14,7 @@ Overview
 ========
 
 The https://gorillastack-jmespath.netlify.com/ site is a static website that uses
-`Sphinx <http://sphinx-doc.org/>`__, a python documentation
+`Sphinx <https://sphinx-doc.org/>`__, a python documentation
 system, under the hood.  If you are familiar with sphinx, then you know how to
 build this static site.
 
@@ -56,7 +56,7 @@ Once you have a virtual environment set up, you can start working on the
 JMESPath site. All the content is under the ``docs/`` folder.  All of the
 content is written using reStructuredText.  If you are not familiar with the
 syntax, the sphinx site has an excellent
-`reStructuredText primer <http://sphinx-doc.org/rest.html>`__.
+`reStructuredText primer <https://sphinx-doc.org/rest.html>`__.
 
 Once you've made changes you can build the docs by running ``make html``.  Make
 sure that you've activated your virtual environment (this was done in the
@@ -69,7 +69,7 @@ rendered html::
   $ cd docs/_build/html
   $ python -m SimpleHTTPServer
 
-You can then view the docs at http://localhost:8000/
+You can then view the docs at https://localhost:8000/
 
 License
 =======

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ JMESPath Site
    :target: https://gitter.im/jmespath/chat
 
 
-This is the repo for the website: http://jmespath.org
+This is the repo for the website: http://gorillastack-jmespath.netlify.com
 
 Join us on our `Gitter channel <https://gitter.im/jmespath/chat>`__.
 
@@ -13,7 +13,7 @@ Join us on our `Gitter channel <https://gitter.im/jmespath/chat>`__.
 Overview
 ========
 
-The http://jmespath.org/ site is a static website that uses
+The https://gorillastack-jmespath.netlify.com/ site is a static website that uses
 `Sphinx <http://sphinx-doc.org/>`__, a python documentation
 system, under the hood.  If you are familiar with sphinx, then you know how to
 build this static site.

--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -17,6 +17,16 @@
 
 <div class="container">
   <div class="row">
+    <div class="alert alert-info" role="alert">
+      This is a forked version of the original JMESPath site maintained by
+      <a href="https://www.gorillastack.com">GorillaStack</a>. It contains
+      a description of the enhancements and changes we have made to the
+      specification (for the JavaScript implementation only) and links to
+      our code repositories.
+    </div>
+  </div>
+
+  <div class="row">
     <div class="col-md-8">
       <div class="jmespath-demo">
         <form>

--- a/docs/_templates/mainlinks.html
+++ b/docs/_templates/mainlinks.html
@@ -5,7 +5,7 @@
 </p>
 <h3>Project Links</h3>
 <ul>
-  <li><a href="http://jmespath.org/">JMESPath website</a></li>
+  <li><a href="https://gorillastack-jmespath.netlify.com/">JMESPath website</a></li>
   <li><a href="http://github.com/jmespath">JMESPath on Github</a></li>
   <li><a href="https://gitter.im/jmespath/chat">JMESPath Chat</a></li>
 </ul>

--- a/docs/_templates/mainlinks.html
+++ b/docs/_templates/mainlinks.html
@@ -5,8 +5,8 @@
 </p>
 <h3>Project Links</h3>
 <ul>
-  <li><a href="https://gorillastack-jmespath.netlify.com/">JMESPath website</a></li>
-  <li><a href="http://github.com/jmespath">JMESPath on Github</a></li>
+  <li><a href="https://gorillastack-jmespath.netlify.com/">GorillaStack JMESPath website</a></li>
+  <li><a href="https://github.com/GorillaStack">GorillaStack on Github (including JMESPath forks)</a></li>
   <li><a href="https://gitter.im/jmespath/chat">JMESPath Chat</a></li>
 </ul>
 

--- a/docs/_themes/jmespath/layout.html
+++ b/docs/_themes/jmespath/layout.html
@@ -4,7 +4,7 @@
   {% set script_files = script_files + ["_static/myscript.js"] %}
   <link rel="stylesheet" type="text/css" href="{{ pathto('_static/css/bootstrap.min.css', 1) }}" />
   <link rel="stylesheet" type="text/css" href="{{ pathto('_static/css/bootstrap-theme.min.css', 1) }}" />
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   {{ super() }}
 {%- endblock %}
@@ -100,7 +100,7 @@ $(document).ready(function() {
   <div class="container">
     {%- if theme_github_user and theme_github_repo %}
     <div class="visible-md visible-lg navbar-text pull-right" id="github-stars">
-      <iframe src="http://ghbtns.com/github-btn.html?user={{ theme_github_user }}&repo={{ theme_github_repo }}&type=watch&count=true&size=small"
+      <iframe src="https://ghbtns.com/github-btn.html?user={{ theme_github_user }}&repo={{ theme_github_repo }}&type=watch&count=true&size=small"
       allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
     </div>
     {%- endif %}

--- a/docs/_themes/jmespath/layout.html
+++ b/docs/_themes/jmespath/layout.html
@@ -116,7 +116,7 @@ $(document).ready(function() {
         <li><a href="/examples.html">Examples</a></li>
         <li><a href="/specification.html">Specification</a></li>
         <li><a href="/libraries.html">Libraries</a></li>
-        <li><a href="https://github.com/jmespath">Github</a></li>
+        <li><a href="https://github.com/GorillaStack">Github</a></li>
       </ul>
     </div>
   </div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ html_title = 'JMESPath'
 html_theme_path = ['_themes']
 
 html_theme_options = {
-    "base_url": "http://jmespath.org",
+    "base_url": "https://gorillastack-jmespath.netlify.com",
 }
 
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -10,9 +10,9 @@ in action.  If you're new to JMESPath, you can start with the
 .. note::
 
   Do you have any examples you'd like to add?  Send a
-  `pull request <https://github.com/jmespath/jmespath.site>`__ on github.
+  `pull request <https://github.com/GorillaStack/jmespath.site>`__ on github.
   Are there examples you'd like to see that aren't here?  Let us know
-  by opening an `issue on github <https://github.com/jmespath/jmespath.site/issues>`__.
+  by opening an `issue on github <https://github.com/GorillaStack/jmespath.site/issues>`__.
 
 
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -457,7 +457,7 @@ Main Page
 ---------
 
 Let's look at a modified version of the expression on the `JMESPath front page
-<http://jmespath.org>`__.
+<https://gorillastack-jmespath.netlify.com>`__.
 
 
 .. jpexample:: locations[?state == 'WA'].name | sort(@)[-2:] | {WashingtonCities: join(', ', @)}

--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -6,6 +6,9 @@ The JMESPath specification is implemented in varioues languages.  Each list
 below shows JMESPath libraries as well as the compliance level.  The compliance
 level is based on which compliance tests the library can pass.
 
+**GorillaStack maintains a fork in JavaScript which is divergent from the
+original specification. Below, we have provided links to the GorillaStack
+versions where approriate or the original implementations.**
 
 .. cssclass:: table
 
@@ -22,8 +25,8 @@ level is based on which compliance tests the library can pass.
     - `jmespath.php <https://github.com/jmespath/jmespath.php>`__
     - Fully compliant
   * - Javascript
-    - `jmespath.js <https://github.com/jmespath/jmespath.js>`__
-    - Fully compliant
+    - `jmespath.js <https://github.com/GorillaStack/jmespath.js>`__
+    - Fully compliant w/ GorillaStack additions
   * - Ruby
     - `jmespath.rb <https://github.com/trevorrowe/jmespath.rb>`__
     - Fully compliant

--- a/docs/libraries.rst
+++ b/docs/libraries.rst
@@ -6,9 +6,11 @@ The JMESPath specification is implemented in varioues languages.  Each list
 below shows JMESPath libraries as well as the compliance level.  The compliance
 level is based on which compliance tests the library can pass.
 
-**GorillaStack maintains a fork in JavaScript which is divergent from the
-original specification. Below, we have provided links to the GorillaStack
-versions where approriate or the original implementations.**
+.. note::
+
+  GorillaStack maintains a fork in JavaScript which is divergent from the
+  original specification. Below, we have provided links to the GorillaStack
+  versions where approriate or the original implementations.
 
 .. cssclass:: table
 
@@ -18,33 +20,43 @@ versions where approriate or the original implementations.**
   * - Language
     - Name
     - Compliance Level
+    - Variant
   * - Python
     - `jmespath.py <https://github.com/jmespath/jmespath.py>`__
     - Fully compliant
+    - Original
   * - PHP
     - `jmespath.php <https://github.com/jmespath/jmespath.php>`__
     - Fully compliant
+    - Original
   * - Javascript
     - `jmespath.js <https://github.com/GorillaStack/jmespath.js>`__
     - Fully compliant w/ GorillaStack additions
+    - GorillaStack
   * - Ruby
     - `jmespath.rb <https://github.com/trevorrowe/jmespath.rb>`__
     - Fully compliant
+    - Original
   * - Lua
     - `jmespath.lua <https://github.com/jmespath/jmespath.lua>`__
     - Fully compliant
+    - Original
   * - Go
     - `go-jmespath <https://github.com/jmespath/go-jmespath>`__
     - Fully compliant
+    - Original
   * - Java
     - `jmespath-java <https://github.com/burtcorp/jmespath-java>`__
     - Fully compliant
+    - Original
   * - Rust
     - `jmespath.rs <https://github.com/mtdowling/jmespath.rs>`__
     - Fully compliant
+    - Original
   * - DotNet
     - `jmespath.net <https://github.com/jdevillard/JmesPath.Net>`__
     - Fully compliant
+    - Original
 
 In addition to the JMESPath libraries above, there are a number of
 miscellaneous JMESPath tools.

--- a/docs/proposals.rst
+++ b/docs/proposals.rst
@@ -18,3 +18,4 @@ changes. Proposals are marked as either "draft", "accepted", or "rejected".
    proposals/improved-filters
    proposals/slice-projections
    proposals/raw-string-literals
+   proposals/string-manipulation

--- a/docs/proposals/functions.rst
+++ b/docs/proposals/functions.rst
@@ -11,7 +11,7 @@ Abstract
 ========
 
 This document proposes modifying the
-`JMESPath grammar <http://jmespath.readthedocs.org/en/latest/specification.html#grammar>`__
+`JMESPath grammar <https://jmespath.readthedocs.org/en/latest/specification.html#grammar>`__
 to support function expressions.
 
 Motivation

--- a/docs/proposals/nested-expressions.rst
+++ b/docs/proposals/nested-expressions.rst
@@ -10,7 +10,7 @@ Nested Expressions
 Abstract
 ========
 
-This document proposes modifying the `JMESPath grammar <http://jmespath.readthedocs.org/en/latest/specification.html#grammar>`_
+This document proposes modifying the `JMESPath grammar <https://jmespath.readthedocs.org/en/latest/specification.html#grammar>`_
 to support arbitrarily nested expressions within ``multi-select-list`` and
 ``multi-select-hash`` expressions.
 
@@ -218,4 +218,4 @@ and is specified using ABNF, as described in `RFC4234`_
                         %x61-7A / ; a-z
                         %x7F-10FFFF
 
-.. _RFC4234: http://tools.ietf.org/html/rfc4234
+.. _RFC4234: https://tools.ietf.org/html/rfc4234

--- a/docs/proposals/pipes.rst
+++ b/docs/proposals/pipes.rst
@@ -100,7 +100,7 @@ The following modified JMESPath grammar supports piped expressions.
                         %x61-7A / ; a-z
                         %x7F-10FFFF
 
-.. _RFC4234: http://tools.ietf.org/html/rfc4234
+.. _RFC4234: https://tools.ietf.org/html/rfc4234
 
 .. note::
 

--- a/docs/proposals/raw-string-literals.rst
+++ b/docs/proposals/raw-string-literals.rst
@@ -31,10 +31,10 @@ Motivation
 ==========
 
 Raw string literals are provided in `various programming languages
-<http://en.wikipedia.org/wiki/String_literal#Raw_strings>`_ in order to prevent
+<https://en.wikipedia.org/wiki/String_literal#Raw_strings>`_ in order to prevent
 language specific interpretation (i.e., JSON parsing) and remove the need for
 escaping, avoiding a common problem called `leaning toothpick syndrome (LTS)
-<http://en.wikipedia.org/wiki/Leaning_toothpick_syndrome>`_. Leaning toothpick
+<https://en.wikipedia.org/wiki/Leaning_toothpick_syndrome>`_. Leaning toothpick
 syndrome is an issue in which strings become unreadable due to excessive use of
 escape characters in order to avoid delimiter collision (e.g., ``\\\\\\``).
 
@@ -296,7 +296,7 @@ Use a customizable delimiter
 ----------------------------
 
 Several languages allow for a custom delimiter to be placed around a raw
-string. For example, Lua allows for a `long bracket <http://www.lua.org/manual/5.2/manual.html#3.1>`_ notation in which raw
+string. For example, Lua allows for a `long bracket <https://www.lua.org/manual/5.2/manual.html#3.1>`_ notation in which raw
 strings are surrounded by ``[[]]`` with any number of balanced `=` characters
 between the brackets::
 
@@ -309,5 +309,5 @@ the appropriate number of matching characters.
 
 The addition of a string literal as described in this JEP does not preclude a
 later addition of a heredoc or delimited style string literal as provided by
-languages like Lua, `D <http://dlang.org/lex.html#DelimitedString>`_,
-`C++ <http://en.wikipedia.org/wiki/C%2B%2B11#New_string_literals>`_, etc...
+languages like Lua, `D <https://dlang.org/lex.html#DelimitedString>`_,
+`C++ <https://en.wikipedia.org/wiki/C%2B%2B11#New_string_literals>`_, etc...

--- a/docs/proposals/string-manipulation.rst
+++ b/docs/proposals/string-manipulation.rst
@@ -1,0 +1,72 @@
+=================
+Slice Projections
+=================
+
+:JEP: xx
+:Author: Chris Armstrong (GorillaStack)
+:Status: draft
+:Created: 31-10-2019
+
+Abstract
+========
+
+This document proposes expanding the list of available string manipulation
+functions in the spec.
+
+Motivation
+==========
+
+The specification only contains basic string search and manipulation functions,
+such as `starts_with()` and `contains()`, which are insufficient for other use
+cases, such as replacing parts of strings, splitting strings, using regular expressions
+for searching or manipulation of strings, or other common string manipulations
+found in the common libraries of mainstream languages such as Python or JavaScript.
+
+Specification
+=============
+
+The following functions will be added to the specification:
+
+split
+-----
+
+::
+    array[string] split(string $subject, string $split_str, number $max = -1)
+
+Given string `$subject`, split will split on occurrences string `$split_str`, up to and including
+$max times (if specified).
+
+The result is an array containing each partial string between occurrences of `$split_str`. If
+the string is
+
+`$max` is a optional parameter. When specified as an integer greater than zero, it will split the
+string up to `($max - 1)` times, with the last string in the array containing the remaining
+contents of `$subject` unmodified.
+
+If not specified or it is less than zero, the string will be split on every occurrence of `$split_str`.
+
+When `$max` is equal to zero, it will behave as if the string is not split at all, and return
+an array containing one element, the original string.
+
+.. cssclass:: table
+
+.. list-table:: Examples
+  :header-rows: 1
+
+  * - Expression
+    - Result
+  * - ``split('average|-|min|-|max|-|mean|-|mode|-|median', '|-|')``
+    - ``["average", "min", "max", "mean", "mode", "median"]``
+  * - ``split('average|-|min|-|max|-|mean|-|mode|-|median', '|-|', 3)``
+    - ``["average", "min", "max|-|mean|-|mode|-|median"]``
+  * - ``split('average|-|min|-|max|-|mean|-|mode|-|median', '-')``
+    - ``["average|", "|min|", "|max|", "|mean|", "|mode|", "|median"]``
+  * - ``split('average|-|min|-|max|-|mean|-|mode|-|median', '|-|', 0)``
+    - ``["average|-|min|-|max|-|mean|-|mode|-|median"]``
+  * - ``split('every character', '')``
+    - ``["e", "v", "e", "r", "y", " ", "c", "h", "a", "r", "a", "c", "t", "e", "r"]``
+
+Impact
+======
+
+There should be no impact to existing users, as these are new functions.

--- a/docs/sitemap.py
+++ b/docs/sitemap.py
@@ -51,7 +51,7 @@ def create_sitemap(app, exception):
     sitemap_filename = os.path.join(app.outdir, 'sitemap.xml')
     print("Generating sitemap.xml in %s" % sitemap_filename)
     root = ET.Element("urlset")
-    root.set("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9")
+    root.set("xmlns", "https://www.sitemaps.org/schemas/sitemap/0.9")
     for link in app.sitemap_links:
         url = ET.SubElement(root, "url")
         ET.SubElement(url, "loc").text = link

--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -834,7 +834,7 @@ Examples
   search(foo[?a==b], {"foo": [{"a": 1, "b": 2}, {"a": 2, "b": 2}]}) -> [{"a": 2, "b": 2}]
 
 
-.. _RFC4234: http://tools.ietf.org/html/rfc4234
+.. _RFC4234: https://tools.ietf.org/html/rfc4234
 
 
 .. _functions:


### PR DESCRIPTION
This PR adds:
- links to GorillaStack repos
- some messaging explaining this is a forked version of the original site
- a spec for string manipulation (see https://github.com/GorillaStack/jmespath.js/pull/4 for implementation)